### PR TITLE
修正 3dgs 渲染旋转方向不正确、椭球朝向偏差

### DIFF
--- a/modeling/GaussianGeometry.cpp
+++ b/modeling/GaussianGeometry.cpp
@@ -127,7 +127,8 @@ void GaussianGeometry::setScaleAndRotation(osg::Vec3Array* vArray, osg::QuatArra
         if (!quat.zeroRotation()) { double l = quat.length(); if (l > 0.0) quat = quat / l; }
 
         osg::Matrix R(quat), S = osg::Matrix::scale(scale);
-        osg::Matrix cov = R * S * transpose(S) * transpose(R);
+        //osg::Matrix cov = R * S * transpose(S) * transpose(R);
+        osg::Matrix cov = transpose(R) * S * S * R;
         (*cov0)[i] = osg::Vec4(cov(0, 0), cov(1, 0), cov(2, 0), a);
         (*cov1)[i] = osg::Vec4(cov(0, 1), cov(1, 1), cov(2, 1), 1.0f);
         (*cov2)[i] = osg::Vec4(cov(0, 2), cov(1, 2), cov(2, 2), 1.0f);


### PR DESCRIPTION
项目中使用的四元含义与 osg::Matrix(quat) 的默认变换顺序不一致
在 GaussianGeometry::setScaleAndRotation中，将osg::Matrix cov = R * S * transpose(S) * transpose(R); 改为 osg::Matrix cov = transpose(R) * S * S * R;
<img width="1860" height="644" alt="fix" src="https://github.com/user-attachments/assets/c3058e8c-587b-467e-8ab8-6737f3ddfebc" />
